### PR TITLE
Fix: lazy-init Sanity client to avoid crash when SANITY_PROJECT_ID is…

### DIFF
--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,4 +1,4 @@
-import { client, isSanityConfigured } from './sanity'
+import { getClient, isSanityConfigured } from './sanity'
 import type { Project, ProjectSummary, SiteSettings } from '../types'
 
 // GROQ queries
@@ -39,14 +39,14 @@ const PROJECT_FULL_FIELDS = `
 
 export async function getAllPublishedProjects(): Promise<ProjectSummary[]> {
   if (!isSanityConfigured()) return []
-  return client.fetch(
+  return getClient().fetch(
     `*[_type == "project" && status == "published"] | order(created_at desc) { ${PROJECT_SUMMARY_FIELDS} }`,
   )
 }
 
 export async function getProjectBySlug(slug: string): Promise<Project | null> {
   if (!isSanityConfigured()) return null
-  const results = await client.fetch<Project[]>(
+  const results = await getClient().fetch<Project[]>(
     `*[_type == "project" && slug.current == $slug && status == "published"][0..0] { ${PROJECT_FULL_FIELDS} }`,
     { slug },
   )
@@ -55,7 +55,7 @@ export async function getProjectBySlug(slug: string): Promise<Project | null> {
 
 export async function getAllProjectSlugs(): Promise<string[]> {
   if (!isSanityConfigured()) return []
-  const results = await client.fetch<{ slug: { current: string } }[]>(
+  const results = await getClient().fetch<{ slug: { current: string } }[]>(
     `*[_type == "project" && status == "published"] { slug }`,
   )
   return results.map((p) => p.slug.current)
@@ -63,5 +63,5 @@ export async function getAllProjectSlugs(): Promise<string[]> {
 
 export async function getSiteSettings(): Promise<SiteSettings | null> {
   if (!isSanityConfigured()) return null
-  return client.fetch(`*[_type == "siteSettings"][0]`)
+  return getClient().fetch(`*[_type == "siteSettings"][0]`)
 }

--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'next-sanity'
+import { createClient, type SanityClient } from 'next-sanity'
 import imageUrlBuilder from '@sanity/image-url'
 import type { SanityImageSource } from '@sanity/image-url'
 
@@ -6,19 +6,24 @@ export const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || ''
 export const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || 'production'
 export const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2025-01-01'
 
-export const client = createClient({
-  projectId,
-  dataset,
-  apiVersion,
-  useCdn: process.env.NODE_ENV === 'production',
-})
-
-const builder = imageUrlBuilder(client)
-
-export function urlFor(source: SanityImageSource) {
-  return builder.image(source)
-}
-
 export function isSanityConfigured(): boolean {
   return Boolean(projectId)
+}
+
+let _client: SanityClient | null = null
+
+export function getClient(): SanityClient {
+  if (!_client) {
+    _client = createClient({
+      projectId,
+      dataset,
+      apiVersion,
+      useCdn: process.env.NODE_ENV === 'production',
+    })
+  }
+  return _client
+}
+
+export function urlFor(source: SanityImageSource) {
+  return imageUrlBuilder(getClient()).image(source)
 }


### PR DESCRIPTION
… unset

createClient throws at import time if projectId is empty. Replace the eager module-level client with a lazy getClient() factory that is only called when a query is actually executed (which is already guarded by isSanityConfigured).

https://claude.ai/code/session_018G1NfwmqdCQaqHRTxufkGX