### PR TITLE
Fix save: strip expanded asset refs and bust ISR cache on publish

### DIFF
--- a/app/admin/edit/[slug]/EditorClient.tsx
+++ b/app/admin/edit/[slug]/EditorClient.tsx
@@ -77,6 +77,7 @@ export default function EditorClient({ initialProject }: EditorClientProps) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             projectId: project._id,
+            slug: project.slug.current,
             sections: project.sections ?? [],
             status: newStatus ?? project.status,
             title: project.title,

--- a/app/api/admin/save/route.ts
+++ b/app/api/admin/save/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
 import { ADMIN_COOKIE, verifySessionToken } from '../../../../lib/adminAuth'
 import { saveProject, type SaveProjectPayload } from '../../../../lib/sanityWrite'
 
@@ -10,13 +11,19 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const payload: SaveProjectPayload = await request.json()
+    const payload: SaveProjectPayload & { slug?: string } = await request.json()
 
     if (!payload.projectId) {
       return NextResponse.json({ error: 'projectId is required' }, { status: 400 })
     }
 
     await saveProject(payload)
+
+    // Bust the Next.js ISR cache so changes appear immediately on the live site
+    revalidatePath('/', 'layout')
+    if (payload.slug) {
+      revalidatePath(`/project/${payload.slug}`)
+    }
 
     return NextResponse.json({ ok: true })
   } catch (err) {

--- a/lib/sanityWrite.ts
+++ b/lib/sanityWrite.ts
@@ -15,6 +15,31 @@ export function getWriteClient() {
   })
 }
 
+/**
+ * GROQ queries expand asset references (asset->{ _id, url, metadata... }).
+ * Sanity cannot store those expanded fields — only _ref and _type belong on a reference.
+ * This recursively strips the extra fields so the patch is clean.
+ */
+function stripExpandedAssets(value: unknown): unknown {
+  if (!value || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map(stripExpandedAssets)
+
+  const obj = value as Record<string, unknown>
+  const result: Record<string, unknown> = {}
+
+  for (const key of Object.keys(obj)) {
+    if (key === 'asset' && obj[key] && typeof obj[key] === 'object' && '_ref' in (obj[key] as object)) {
+      // Keep only the reference fields — discard _id, url, metadata, etc.
+      const ref = obj[key] as Record<string, unknown>
+      result[key] = { _type: ref._type ?? 'reference', _ref: ref._ref }
+    } else {
+      result[key] = stripExpandedAssets(obj[key])
+    }
+  }
+
+  return result
+}
+
 export interface SaveProjectPayload {
   projectId: string
   sections: Section[]
@@ -27,8 +52,11 @@ export interface SaveProjectPayload {
 export async function saveProject(payload: SaveProjectPayload): Promise<void> {
   const client = getWriteClient()
 
+  // Strip expanded asset data before writing — Sanity only accepts plain references
+  const cleanSections = stripExpandedAssets(payload.sections) as Section[]
+
   const patch: Record<string, unknown> = {
-    sections: payload.sections,
+    sections: cleanSections,
   }
 
   if (payload.status !== undefined) patch.status = payload.status


### PR DESCRIPTION
Two bugs prevented layout changes from appearing on the live site:

1. GROQ asset expansion (asset->{ _id, url, metadata }) was being saved back to Sanity verbatim. Sanity references only accept _ref + _type — the extra fields caused the patch to fail or corrupt data silently. Added stripExpandedAssets() to clean sections before writing.

2. Next.js ISR caches project pages for 60s. Added revalidatePath() in the save API route so the cache is busted immediately on save/publish. The slug is now passed from the editor so the correct page path is invalidated.

https://claude.ai/code/session_01VseUPiJK6DTv8Ge47dgDwt