### PR TITLE
Fix image asset checks to use optional chaining on asset property

### DIFF
--- a/app/project/[slug]/page.tsx
+++ b/app/project/[slug]/page.tsx
@@ -30,9 +30,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!project) return {}
 
   const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://coleanderson.com'
-  const ogImageUrl = project.og_image
+  const ogImageUrl = project.og_image?.asset
     ? urlFor(project.og_image).width(1200).height(630).auto('format').url()
-    : project.cover_image
+    : project.cover_image?.asset
       ? urlFor(project.cover_image).width(1200).height(630).auto('format').url()
       : undefined
 
@@ -78,11 +78,11 @@ export default async function ProjectPage({ params }: PageProps) {
 
   if (!project) notFound()
 
-  const coverUrl = project.cover_image
+  const coverUrl = project.cover_image?.asset
     ? urlFor(project.cover_image).width(1400).auto('format').url()
     : null
 
-  const coverThumb = project.cover_image
+  const coverThumb = project.cover_image?.asset
     ? urlFor(project.cover_image).width(40).blur(10).url()
     : null
 

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -7,7 +7,7 @@ interface HeroSectionProps {
 }
 
 export default function HeroSectionComponent({ section }: HeroSectionProps) {
-  const bgUrl = section.backgroundImage
+  const bgUrl = section.backgroundImage?.asset
     ? urlFor(section.backgroundImage)
         .width(1600)
         .height(900)

--- a/components/sections/ImageSection.tsx
+++ b/components/sections/ImageSection.tsx
@@ -7,7 +7,7 @@ interface ImageSectionProps {
 }
 
 export default function ImageSectionComponent({ section }: ImageSectionProps) {
-  if (!section.image) return null;
+  if (!section.image?.asset) return null;
 
   const aspectRatio = section.aspectRatio ?? "16/10";
   const objectFit = (section.objectFit as "cover" | "contain" | "fill") ?? "cover";

--- a/components/sections/SplitSection.tsx
+++ b/components/sections/SplitSection.tsx
@@ -27,7 +27,7 @@ function renderContent(content: BlockContent[]) {
 }
 
 export default function SplitSectionComponent({ section }: SplitSectionProps) {
-  if (!section.image) return null;
+  if (!section.image?.asset) return null;
 
   const imageAspectRatio = section.imageAspectRatio ?? "4/3";
   const verticalAlign = section.verticalAlign ?? "center";


### PR DESCRIPTION
## Summary
Updated image existence checks throughout the codebase to properly validate the `asset` property of image objects before attempting to process them with the `urlFor()` function.

## Key Changes
- **app/project/[slug]/page.tsx**: Modified `og_image` and `cover_image` existence checks to verify `?.asset` property instead of the image object itself in both `generateMetadata()` and `ProjectPage()` functions
- **components/sections/HeroSection.tsx**: Updated `backgroundImage` check to validate `?.asset` property
- **components/sections/ImageSection.tsx**: Changed image existence check from `section.image` to `section.image?.asset`
- **components/sections/SplitSection.tsx**: Changed image existence check from `section.image` to `section.image?.asset`

## Implementation Details
These changes ensure that the code properly checks for the presence of the actual image asset before attempting to use the `urlFor()` utility function. This prevents potential errors when image objects exist but lack an asset reference, which appears to be the expected structure for Sanity image objects in this codebase.

https://claude.ai/code/session_013CpJvyJ9zsBakJUVDPU2Lf