### PR TITLE
Fix image rendering bugs and remove freemove from predefined sections

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 # TODO
 
-- [ ] Remove freemove option from predefined sections (ie image, maybe others)
-- [ ] Get free image/video/text object displaying in /admin/edit (currently just showing a blank area)
+- [x] Remove freemove option from predefined sections (ie image, maybe others)
+- [x] Get free image/video/text object displaying in /admin/edit (currently just showing a blank area)
 - [ ] Allow adding blank space in between sections (in /admin/edit)
 - [ ] Ensure how page is shown in /admin/edit, is the same as how it's shown on the website
-- [ ] Free image/video/text objects not showing on website
+- [x] Free image/video/text objects not showing on website
 - [ ] Make images/videos load faster. Maybe lazy load? Or move off sanity to static site (like decap)?

--- a/app/admin/edit/[slug]/EditableFreeObject.tsx
+++ b/app/admin/edit/[slug]/EditableFreeObject.tsx
@@ -77,7 +77,7 @@ const fontSizeMap: Record<string, string> = {
 // --- Content renderers — no positioning wrapper, matches public page visuals ---
 
 function ImageContent({ obj }: { obj: FreeImageObject }) {
-  if (!obj.image?.asset?._ref) {
+  if (!obj.image?.asset) {
     return (
       <div className="w-full h-24 bg-neutral-200 flex items-center justify-center text-xs text-neutral-400">
         No image

--- a/app/admin/edit/[slug]/EditableSection.tsx
+++ b/app/admin/edit/[slug]/EditableSection.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import React, { useRef, useCallback } from 'react'
-import type { Section, ImageSection } from '../../../../types'
-import { urlFor } from '../../../../lib/sanity'
-import Image from 'next/image'
+import React, { useRef } from 'react'
+import type { Section } from '../../../../types'
 import HeroSectionComponent from '../../../../components/sections/HeroSection'
 import TextSectionComponent from '../../../../components/sections/TextSection'
 import ImageSectionComponent from '../../../../components/sections/ImageSection'
@@ -35,170 +33,6 @@ function sectionLabel(type: string): string {
   return labels[type] ?? type
 }
 
-type DragType = 'move' | 'resize-br' | 'resize-bl' | 'resize-tr' | 'resize-tl'
-
-interface DraggableImageOverlayProps {
-  section: ImageSection
-  onChange: (patch: Partial<ImageSection>) => void
-  containerRef: React.RefObject<HTMLDivElement>
-}
-
-// Hooks are always called first — no conditional before hooks.
-function DraggableImageOverlay({ section, onChange, containerRef }: DraggableImageOverlayProps) {
-  const xPercent = section.xPercent ?? 0
-  const yPercent = section.yPercent ?? 0
-  const widthPercent = section.widthPercent ?? 100
-  const rotation = section.rotation ?? 0
-  const opacity = section.opacity ?? 1
-  const zIndex = section.zIndex ?? 0
-
-  const dragState = useRef<{
-    type: DragType
-    startX: number
-    startY: number
-    startXPct: number
-    startYPct: number
-    startWPct: number
-  } | null>(null)
-
-  const startInteraction = useCallback(
-    (e: React.MouseEvent, type: DragType) => {
-      e.preventDefault()
-      e.stopPropagation()
-
-      dragState.current = {
-        type,
-        startX: e.clientX,
-        startY: e.clientY,
-        startXPct: xPercent,
-        startYPct: yPercent,
-        startWPct: widthPercent,
-      }
-
-      const onMouseMove = (me: MouseEvent) => {
-        if (!dragState.current || !containerRef.current) return
-        const rect = containerRef.current.getBoundingClientRect()
-        const dx = ((me.clientX - dragState.current.startX) / rect.width) * 100
-        const dy = ((me.clientY - dragState.current.startY) / rect.height) * 100
-
-        if (dragState.current.type === 'move') {
-          onChange({
-            xPercent: Math.round(dragState.current.startXPct + dx),
-            yPercent: Math.round(dragState.current.startYPct + dy),
-          })
-        } else {
-          const sign = dragState.current.type.endsWith('r') ? 1 : -1
-          const newW = Math.max(10, dragState.current.startWPct + dx * sign)
-          onChange({ widthPercent: Math.round(newW) })
-        }
-      }
-
-      const onMouseUp = () => {
-        dragState.current = null
-        document.removeEventListener('mousemove', onMouseMove)
-        document.removeEventListener('mouseup', onMouseUp)
-      }
-
-      document.addEventListener('mousemove', onMouseMove)
-      document.addEventListener('mouseup', onMouseUp)
-    },
-    [xPercent, yPercent, widthPercent, onChange, containerRef],
-  )
-
-  // Guard after hooks
-  if (!section.image) return null
-
-  const imageUrl = urlFor(section.image).width(1400).auto('format').url()
-  const thumbUrl = urlFor(section.image).width(40).blur(10).url()
-  const objectFit = (section.objectFit as 'cover' | 'contain' | 'fill') ?? 'cover'
-
-  const handleStyle: React.CSSProperties = {
-    position: 'absolute',
-    width: 14,
-    height: 14,
-    background: 'white',
-    border: '2px solid #3b82f6',
-    borderRadius: 3,
-  }
-
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        left: `${xPercent}%`,
-        top: `${yPercent}%`,
-        width: `${widthPercent}%`,
-        zIndex,
-        transform: rotation ? `rotate(${rotation}deg)` : undefined,
-        opacity,
-        cursor: 'move',
-        userSelect: 'none',
-      }}
-      onMouseDown={(e) => startInteraction(e, 'move')}
-    >
-      <Image
-        src={imageUrl}
-        alt={section.image.alt ?? ''}
-        width={1400}
-        height={875}
-        className="w-full h-auto block"
-        style={{ objectFit, filter: section.grayscale ? 'grayscale(1)' : undefined }}
-        placeholder={thumbUrl ? 'blur' : 'empty'}
-        blurDataURL={thumbUrl}
-        draggable={false}
-      />
-
-      {/* Resize handles */}
-      <div
-        style={{ ...handleStyle, bottom: -6, right: -6, cursor: 'se-resize', zIndex: 10 }}
-        onMouseDown={(e) => startInteraction(e, 'resize-br')}
-      />
-      <div
-        style={{ ...handleStyle, bottom: -6, left: -6, cursor: 'sw-resize', zIndex: 10 }}
-        onMouseDown={(e) => startInteraction(e, 'resize-bl')}
-      />
-      <div
-        style={{ ...handleStyle, top: -6, right: -6, cursor: 'ne-resize', zIndex: 10 }}
-        onMouseDown={(e) => startInteraction(e, 'resize-tr')}
-      />
-      <div
-        style={{ ...handleStyle, top: -6, left: -6, cursor: 'nw-resize', zIndex: 10 }}
-        onMouseDown={(e) => startInteraction(e, 'resize-tl')}
-      />
-
-      {/* Move hint */}
-      <div
-        style={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          background: 'rgba(59,130,246,0.85)',
-          color: 'white',
-          fontSize: 11,
-          padding: '3px 8px',
-          borderRadius: 4,
-          pointerEvents: 'none',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        ✥ drag to move
-      </div>
-
-      {/* Blue outline */}
-      <div
-        style={{
-          position: 'absolute',
-          inset: 0,
-          outline: '2px solid #3b82f6',
-          outlineOffset: 2,
-          pointerEvents: 'none',
-        }}
-      />
-    </div>
-  )
-}
-
 export default function EditableSection({
   section,
   index,
@@ -208,12 +42,8 @@ export default function EditableSection({
   onMoveUp,
   onMoveDown,
   onDelete,
-  onChange,
 }: EditableSectionProps) {
   const containerRef = useRef<HTMLDivElement>(null)
-  const isFreeImage =
-    section._type === 'imageSection' && (section as ImageSection).positionMode === 'free'
-  const sectionHeight = isFreeImage ? ((section as ImageSection).sectionHeight ?? 500) : undefined
 
   return (
     <div
@@ -269,41 +99,7 @@ export default function EditableSection({
       </div>
 
       {/* Section content */}
-      {isFreeImage ? (
-        <div
-          style={{
-            position: 'relative',
-            height: sectionHeight,
-            overflow: 'hidden',
-            background: '#f5f5f5',
-          }}
-        >
-          <DraggableImageOverlay
-            section={section as ImageSection}
-            onChange={(patch) => onChange(patch as Partial<Section>)}
-            containerRef={containerRef as React.RefObject<HTMLDivElement>}
-          />
-          {isSelected && (
-            <div
-              style={{
-                position: 'absolute',
-                bottom: 8,
-                right: 8,
-                background: 'rgba(0,0,0,0.5)',
-                color: 'white',
-                fontSize: 10,
-                padding: '2px 6px',
-                borderRadius: 3,
-                pointerEvents: 'none',
-              }}
-            >
-              Free canvas — {sectionHeight}px
-            </div>
-          )}
-        </div>
-      ) : (
-        <div style={{ pointerEvents: 'none' }}>{renderSection(section)}</div>
-      )}
+      <div style={{ pointerEvents: 'none' }}>{renderSection(section)}</div>
     </div>
   )
 }

--- a/app/admin/edit/[slug]/PropertiesPanel.tsx
+++ b/app/admin/edit/[slug]/PropertiesPanel.tsx
@@ -373,8 +373,6 @@ function ImagePanel({
   section: ImageSection
   onChange: (patch: Partial<ImageSection>) => void
 }) {
-  const isFree = section.positionMode === 'free'
-
   return (
     <div className="space-y-4">
       <Field label="Caption">
@@ -446,80 +444,6 @@ function ImagePanel({
           step={0.05}
         />
       </Field>
-
-      <SectionDivider label="Position Mode" />
-
-      <Field label="Mode">
-        <SelectInput
-          value={section.positionMode ?? 'flow'}
-          onChange={(v) => onChange({ positionMode: v as ImageSection['positionMode'] })}
-          options={[
-            { label: 'Normal (flow layout)', value: 'flow' },
-            { label: 'Free (drag anywhere)', value: 'free' },
-          ]}
-        />
-      </Field>
-
-      {isFree && (
-        <>
-          <Field label={`Canvas Height: ${section.sectionHeight ?? 500}px`}>
-            <NumberInput
-              value={section.sectionHeight ?? 500}
-              onChange={(v) => onChange({ sectionHeight: v })}
-              min={100}
-              max={2000}
-              step={50}
-            />
-          </Field>
-
-          <SectionDivider label="Free Position" />
-
-          <Field label={`X Position: ${section.xPercent ?? 0}%`}>
-            <NumberInput
-              value={section.xPercent ?? 0}
-              onChange={(v) => onChange({ xPercent: v })}
-              min={-50}
-              max={150}
-            />
-          </Field>
-
-          <Field label={`Y Position: ${section.yPercent ?? 0}%`}>
-            <NumberInput
-              value={section.yPercent ?? 0}
-              onChange={(v) => onChange({ yPercent: v })}
-              min={-50}
-              max={150}
-            />
-          </Field>
-
-          <Field label={`Width: ${section.widthPercent ?? 100}%`}>
-            <NumberInput
-              value={section.widthPercent ?? 100}
-              onChange={(v) => onChange({ widthPercent: v })}
-              min={5}
-              max={200}
-            />
-          </Field>
-
-          <Field label={`Z-Index: ${section.zIndex ?? 0}`}>
-            <NumberInput
-              value={section.zIndex ?? 0}
-              onChange={(v) => onChange({ zIndex: v })}
-              min={0}
-              max={20}
-            />
-          </Field>
-
-          <Field label={`Rotation: ${section.rotation ?? 0}\u00B0`}>
-            <NumberInput
-              value={section.rotation ?? 0}
-              onChange={(v) => onChange({ rotation: v })}
-              min={-180}
-              max={180}
-            />
-          </Field>
-        </>
-      )}
     </div>
   )
 }

--- a/components/sections/FreeImageObject.tsx
+++ b/components/sections/FreeImageObject.tsx
@@ -9,7 +9,7 @@ interface FreeImageObjectProps {
 export default function FreeImageObjectComponent({
   obj,
 }: FreeImageObjectProps) {
-  if (!obj.image?.asset?._ref) return null;
+  if (!obj.image?.asset) return null;
 
   const x = obj.xPercent ?? 10;
   const y = obj.yPercent ?? 10;

--- a/components/sections/ImageSection.tsx
+++ b/components/sections/ImageSection.tsx
@@ -7,7 +7,7 @@ interface ImageSectionProps {
 }
 
 export default function ImageSectionComponent({ section }: ImageSectionProps) {
-  if (!section.image?.asset?._ref) return null;
+  if (!section.image?.asset) return null;
 
   const aspectRatio = section.aspectRatio ?? "16/10";
   const objectFit =
@@ -15,67 +15,9 @@ export default function ImageSectionComponent({ section }: ImageSectionProps) {
   const borderRadius = section.borderRadius ?? 2;
   const grayscale = section.grayscale ?? false;
   const opacity = section.opacity ?? 1;
-  const isFree = section.positionMode === "free";
 
   const imageUrl = urlFor(section.image).width(1400).auto("format").url();
   const thumbUrl = urlFor(section.image).width(40).blur(10).url();
-
-  if (isFree) {
-    const sectionHeight = section.sectionHeight ?? 500;
-    const x = section.xPercent ?? 0;
-    const y = section.yPercent ?? 0;
-    const width = section.widthPercent ?? 100;
-    const zIndex = section.zIndex ?? 0;
-    const rotation = section.rotation ?? 0;
-
-    return (
-      <section
-        className="py-3"
-        style={{
-          position: "relative",
-          minHeight: sectionHeight,
-          overflow: "hidden",
-        }}
-      >
-        <div
-          style={{
-            position: "absolute",
-            left: `${x}%`,
-            top: `${y}%`,
-            width: `${width}%`,
-            zIndex,
-            transform: rotation ? `rotate(${rotation}deg)` : undefined,
-            opacity,
-          }}
-        >
-          <Image
-            src={imageUrl}
-            alt={section.image.alt ?? ""}
-            width={1400}
-            height={875}
-            className="block h-auto w-full"
-            style={{
-              objectFit,
-              filter: grayscale ? "grayscale(1)" : undefined,
-              borderRadius,
-            }}
-            placeholder={thumbUrl ? "blur" : "empty"}
-            blurDataURL={thumbUrl}
-            sizes="100vw"
-            loading="lazy"
-          />
-        </div>
-        {section.caption && (
-          <figcaption
-            className="absolute bottom-2 text-xs text-neutral-400"
-            style={{ zIndex: zIndex + 1 }}
-          >
-            {section.caption}
-          </figcaption>
-        )}
-      </section>
-    );
-  }
 
   return (
     <section className="py-3">

--- a/sanity/schemas/sections.ts
+++ b/sanity/schemas/sections.ts
@@ -302,58 +302,6 @@ export const imageSection = defineType({
       initialValue: 1,
       validation: (r) => r.min(0).max(1),
     },
-    {
-      name: 'positionMode',
-      title: 'Position Mode',
-      type: 'string',
-      initialValue: 'flow',
-      options: {
-        list: [
-          { title: 'Normal (flow layout)', value: 'flow' },
-          { title: 'Free (drag anywhere)', value: 'free' },
-        ],
-        layout: 'radio',
-      },
-    },
-    {
-      name: 'sectionHeight',
-      title: 'Canvas Height (px) — Free mode only',
-      type: 'number',
-      initialValue: 500,
-      validation: (r) => r.min(100).max(2000),
-    },
-    {
-      name: 'xPercent',
-      title: 'X Position (%)',
-      type: 'number',
-      initialValue: 0,
-    },
-    {
-      name: 'yPercent',
-      title: 'Y Position (%)',
-      type: 'number',
-      initialValue: 0,
-    },
-    {
-      name: 'widthPercent',
-      title: 'Width (%)',
-      type: 'number',
-      initialValue: 100,
-      validation: (r) => r.min(5).max(200),
-    },
-    {
-      name: 'zIndex',
-      title: 'Z-Index (layer order)',
-      type: 'number',
-      initialValue: 0,
-    },
-    {
-      name: 'rotation',
-      title: 'Rotation (°)',
-      type: 'number',
-      initialValue: 0,
-      validation: (r) => r.min(-180).max(180),
-    },
   ],
   preview: {
     select: { title: 'caption', media: 'image' },

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,9 +1,8 @@
 export interface SanityImage {
   _type: "image";
-  asset: {
-    _ref: string;
-    _type: "reference";
-  };
+  asset:
+    | { _ref: string; _type: "reference" }
+    | { _id: string; url: string; metadata?: { dimensions?: { width: number; height: number }; lqip?: string } };
   hotspot?: {
     x: number;
     y: number;
@@ -61,13 +60,6 @@ export interface ImageSection {
   borderRadius?: number;
   grayscale?: boolean;
   opacity?: number;
-  positionMode?: "flow" | "free";
-  sectionHeight?: number;
-  xPercent?: number;
-  yPercent?: number;
-  widthPercent?: number;
-  zIndex?: number;
-  rotation?: number;
 }
 
 export interface GallerySection {


### PR DESCRIPTION
- Fix asset._ref check: GROQ resolves asset references with asset->{ _id }
  so checking asset._ref was always falsy, causing free images and image
  sections to never render. Now checks asset presence instead.
- Update SanityImage type to reflect resolved vs reference asset shapes.
- Remove freemove/free-position option from imageSection: remove positionMode,
  sectionHeight, xPercent, yPercent, widthPercent, zIndex, rotation fields
  from schema, types, ImageSection component, EditableSection, and PropertiesPanel.
  Free positioning is handled by dedicated freeImageObject/freeVideoObject/freeTextObject.

https://claude.ai/code/session_01F61sEszyhZodf8pC3nahRq