### PR TITLE
fix: resolve TypeScript error in SplitSection asset check

### DIFF
--- a/components/sections/SplitSection.tsx
+++ b/components/sections/SplitSection.tsx
@@ -27,7 +27,7 @@ function renderContent(content: BlockContent[]) {
 }
 
 export default function SplitSectionComponent({ section }: SplitSectionProps) {
-  if (!section.image?.asset?._ref) return null;
+  if (!section.image?.asset) return null;
 
   const imageAspectRatio = section.imageAspectRatio ?? "4/3";
   const verticalAlign = section.verticalAlign ?? "center";


### PR DESCRIPTION
The `asset` field is a union type that can be either an unresolved
reference ({ _ref, _type }) or a resolved asset ({ _id, url, metadata }).
Accessing `._ref` directly caused a TS error since it doesn't exist on
the resolved variant. Narrowed the guard to simply check asset existence,
which is valid for both union members and sufficient for urlFor().

https://claude.ai/code/session_01K4FpqktwYDsdkUP9teXTKY