### PR TITLE
Add native video file support and improve video loading UX

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,30 @@
+import { revalidatePath } from "next/cache";
+import { NextRequest } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const secret = req.headers.get("x-webhook-secret");
+  if (!secret || secret !== process.env.SANITY_REVALIDATE_SECRET) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { slug?: { current?: string }; _type?: string } = {};
+  try {
+    body = await req.json();
+  } catch {
+    // no body — revalidate everything
+  }
+
+  const slug = body?.slug?.current ?? null;
+
+  // Always revalidate home page (project list)
+  revalidatePath("/");
+
+  if (slug) {
+    revalidatePath(`/project/${slug}`);
+  } else {
+    // No slug provided (e.g. siteSettings change) — revalidate all project paths
+    revalidatePath("/project/[slug]", "page");
+  }
+
+  return Response.json({ revalidated: true, slug });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { getAllPublishedProjects, getSiteSettings } from "../lib/queries";
 import { urlFor } from "../lib/sanity";
 import { personJsonLd, websiteJsonLd } from "../lib/structured-data";
 
-export const revalidate = 60;
+export const revalidate = false;
 
 /**
  * This is used to display the home page.
@@ -55,13 +55,18 @@ export default async function HomePage() {
                 className="flex flex-col gap-10"
                 aria-label={`${name} projects`}
               >
-                {projects.map((project) => {
+                {projects.map((project, index) => {
                   const cover = project.cover_image
                     ? urlFor(project.cover_image)
                         .width(1600)
                         .auto("format")
                         .url()
                     : null;
+
+                  const asset = project.cover_image?.asset;
+                  const resolvedAsset =
+                    asset && "_id" in asset ? asset : null;
+                  const blurUrl = resolvedAsset?.metadata?.lqip ?? null;
 
                   return (
                     <Link
@@ -78,6 +83,9 @@ export default async function HomePage() {
                             height={1100}
                             className="h-auto w-full"
                             sizes="(max-width: 899px) 100vw, min(1040px, 78vw)"
+                            priority={index === 0}
+                            placeholder={blurUrl ? "blur" : "empty"}
+                            blurDataURL={blurUrl ?? undefined}
                           />
                         </div>
                       )}

--- a/app/project/[slug]/page.tsx
+++ b/app/project/[slug]/page.tsx
@@ -13,7 +13,7 @@ import Header from "../../../components/Header";
 import SectionRenderer from "../../../components/SectionRenderer";
 import FreeObjectRenderer from "../../../components/FreeObjectRenderer";
 
-export const revalidate = 60;
+export const revalidate = false;
 
 interface PageProps {
   params: Promise<{ slug: string }>;

--- a/components/sections/FreeVideoObject.tsx
+++ b/components/sections/FreeVideoObject.tsx
@@ -14,11 +14,6 @@ function getVimeoId(url: string): string | null {
 export default function FreeVideoObjectComponent({
   obj,
 }: FreeVideoObjectProps) {
-  if (!obj.vimeoUrl) return null;
-
-  const videoId = getVimeoId(obj.vimeoUrl);
-  if (!videoId) return null;
-
   const x = obj.xPercent ?? 10;
   const y = obj.yPercent ?? 10;
   const width = obj.widthPercent ?? 40;
@@ -27,6 +22,43 @@ export default function FreeVideoObjectComponent({
   const opacity = obj.opacity ?? 1;
   const aspectRatio = obj.aspectRatio ?? "16/9";
   const borderRadius = obj.borderRadius ?? 0;
+
+  const nativeUrl = obj.videoFile?.asset?.url ?? null;
+
+  const containerStyle = {
+    position: "absolute" as const,
+    left: `${x}%`,
+    top: `${y}%`,
+    width: `${width}%`,
+    zIndex,
+    transform: rotation ? `rotate(${rotation}deg)` : undefined,
+    opacity,
+  };
+
+  if (nativeUrl) {
+    return (
+      <div style={containerStyle}>
+        <div
+          className="overflow-hidden bg-neutral-900"
+          style={{ aspectRatio, borderRadius }}
+        >
+          <video
+            src={nativeUrl}
+            autoPlay={obj.autoplay}
+            muted
+            playsInline
+            loop={obj.loop}
+            preload="metadata"
+            className="h-full w-full object-cover"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (!obj.vimeoUrl) return null;
+  const videoId = getVimeoId(obj.vimeoUrl);
+  if (!videoId) return null;
 
   const params = new URLSearchParams({
     autoplay: obj.autoplay ? "1" : "0",
@@ -37,21 +69,10 @@ export default function FreeVideoObjectComponent({
     portrait: "0",
     dnt: "1",
   });
-
   const embedUrl = `https://player.vimeo.com/video/${videoId}?${params.toString()}`;
 
   return (
-    <div
-      style={{
-        position: "absolute",
-        left: `${x}%`,
-        top: `${y}%`,
-        width: `${width}%`,
-        zIndex,
-        transform: rotation ? `rotate(${rotation}deg)` : undefined,
-        opacity,
-      }}
-    >
+    <div style={containerStyle}>
       <div
         className="overflow-hidden bg-neutral-900"
         style={{ aspectRatio, borderRadius }}

--- a/components/sections/VideoSection.tsx
+++ b/components/sections/VideoSection.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { useState } from "react";
+import Image from "next/image";
 import type { VideoSection } from "../../types";
+import { urlFor } from "../../lib/sanity";
 
 interface VideoSectionProps {
   section: VideoSection;
@@ -12,16 +15,54 @@ function getVimeoId(url: string): string | null {
 }
 
 export default function VideoSectionComponent({ section }: VideoSectionProps) {
-  if (!section.vimeoUrl) return null;
-
-  const videoId = getVimeoId(section.vimeoUrl);
-  if (!videoId) return null;
+  const [vimeoLoaded, setVimeoLoaded] = useState(false);
 
   const aspectRatio = section.aspectRatio ?? "16/9";
   const borderRadius = section.borderRadius ?? 2;
 
+  const nativeUrl = section.videoFile?.asset?.url ?? null;
+
+  // --- Native video (uploaded file) ---
+  if (nativeUrl) {
+    const posterUrl =
+      section.poster?.asset && "_id" in section.poster.asset
+        ? urlFor(section.poster).width(1400).auto("format").url()
+        : null;
+
+    return (
+      <section className="px-8 py-6">
+        <figure>
+          <div
+            className="overflow-hidden bg-neutral-900"
+            style={{ aspectRatio, borderRadius }}
+          >
+            <video
+              src={nativeUrl}
+              poster={posterUrl ?? undefined}
+              controls
+              playsInline
+              loop={section.loop}
+              preload="metadata"
+              className="h-full w-full object-cover"
+            />
+          </div>
+          {section.caption && (
+            <figcaption className="mt-2 text-xs text-neutral-400">
+              {section.caption}
+            </figcaption>
+          )}
+        </figure>
+      </section>
+    );
+  }
+
+  // --- Vimeo embed (facade pattern) ---
+  if (!section.vimeoUrl) return null;
+  const videoId = getVimeoId(section.vimeoUrl);
+  if (!videoId) return null;
+
   const params = new URLSearchParams({
-    autoplay: "0",
+    autoplay: "1",
     muted: "1",
     loop: section.loop ? "1" : "0",
     title: "0",
@@ -29,26 +70,71 @@ export default function VideoSectionComponent({ section }: VideoSectionProps) {
     portrait: "0",
     dnt: "1",
   });
-
   const embedUrl = `https://player.vimeo.com/video/${videoId}?${params.toString()}`;
+
+  const posterUrl =
+    section.poster?.asset && "_id" in section.poster.asset
+      ? urlFor(section.poster).width(1400).auto("format").url()
+      : null;
+
+  const posterLqip =
+    section.poster?.asset && "_id" in section.poster.asset
+      ? (section.poster.asset as { metadata?: { lqip?: string } }).metadata
+          ?.lqip ?? null
+      : null;
 
   return (
     <section className="px-8 py-6">
       <figure>
         <div
-          className="overflow-hidden bg-neutral-900"
+          className="relative overflow-hidden bg-neutral-900"
           style={{ aspectRatio, borderRadius }}
         >
-          <iframe
-            src={embedUrl}
-            title={section.caption ?? "Video"}
-            className="h-full w-full"
-            width="100%"
-            height="100%"
-            allow="autoplay; fullscreen; picture-in-picture"
-            allowFullScreen
-            loading="lazy"
-          />
+          {vimeoLoaded ? (
+            <iframe
+              src={embedUrl}
+              title={section.caption ?? "Video"}
+              className="h-full w-full"
+              width="100%"
+              height="100%"
+              allow="autoplay; fullscreen; picture-in-picture"
+              allowFullScreen
+            />
+          ) : (
+            <button
+              type="button"
+              className="group relative h-full w-full cursor-pointer"
+              onClick={() => setVimeoLoaded(true)}
+              aria-label="Play video"
+            >
+              {posterUrl ? (
+                <Image
+                  src={posterUrl}
+                  alt={section.poster?.alt ?? section.caption ?? "Video thumbnail"}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 899px) 100vw, min(1040px, 78vw)"
+                  placeholder={posterLqip ? "blur" : "empty"}
+                  blurDataURL={posterLqip ?? undefined}
+                />
+              ) : (
+                <div className="h-full w-full bg-neutral-900" />
+              )}
+              {/* Play button */}
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/20 backdrop-blur-sm transition-transform group-hover:scale-110">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="white"
+                    className="h-7 w-7 translate-x-0.5"
+                    aria-hidden="true"
+                  >
+                    <path d="M8 5v14l11-7z" />
+                  </svg>
+                </div>
+              </div>
+            </button>
+          )}
         </div>
         {section.caption && (
           <figcaption className="mt-2 text-xs text-neutral-400">

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -33,13 +33,17 @@ const PROJECT_FULL_FIELDS = `
       backgroundImage { ..., asset->{ _id, url, metadata { dimensions, lqip } } }
     },
     _type == 'videoSection' => {
-      poster { ..., asset->{ _id, url, metadata { dimensions } } }
+      poster { ..., asset->{ _id, url, metadata { dimensions } } },
+      videoFile { asset->{ url } }
     }
   },
   freeObjects[] {
     ...,
     _type == 'freeImageObject' => {
       image { ..., asset->{ _id, url, metadata { dimensions, lqip } } }
+    },
+    _type == 'freeVideoObject' => {
+      videoFile { asset->{ url } }
     }
   }
 `;

--- a/sanity/schemas/sections.ts
+++ b/sanity/schemas/sections.ts
@@ -409,10 +409,17 @@ export const videoSection = defineType({
   type: 'object',
   fields: [
     {
+      name: 'videoFile',
+      title: 'Video File',
+      type: 'file',
+      description: 'Upload an MP4/WebM directly. Takes priority over Vimeo URL.',
+      options: { accept: 'video/*' },
+    },
+    {
       name: 'vimeoUrl',
       title: 'Vimeo URL',
       type: 'url',
-      validation: (r) => r.required(),
+      description: 'Used as fallback when no video file is uploaded.',
     },
     {
       name: 'caption',
@@ -468,8 +475,11 @@ export const videoSection = defineType({
     },
   ],
   preview: {
-    select: { title: 'caption', url: 'vimeoUrl' },
-    prepare: ({ title, url }) => ({ title: title || 'Video Section', subtitle: url }),
+    select: { title: 'caption', url: 'vimeoUrl', file: 'videoFile' },
+    prepare: ({ title, url, file }) => ({
+      title: title || 'Video Section',
+      subtitle: file?.asset ? 'Uploaded file' : url || 'No video set',
+    }),
   },
 })
 
@@ -647,10 +657,17 @@ export const freeVideoObject = defineType({
   type: 'object',
   fields: [
     defineField({
+      name: 'videoFile',
+      title: 'Video File',
+      type: 'file',
+      description: 'Upload an MP4/WebM directly. Takes priority over Vimeo URL.',
+      options: { accept: 'video/*' },
+    }),
+    defineField({
       name: 'vimeoUrl',
       title: 'Vimeo URL',
       type: 'url',
-      validation: (r) => r.required(),
+      description: 'Used as fallback when no video file is uploaded.',
     }),
     defineField({
       name: 'autoplay',
@@ -689,8 +706,11 @@ export const freeVideoObject = defineType({
     ...freePositionFields,
   ],
   preview: {
-    select: { url: 'vimeoUrl' },
-    prepare: ({ url }) => ({ title: 'Free Video', subtitle: url || 'No URL set' }),
+    select: { url: 'vimeoUrl', file: 'videoFile' },
+    prepare: ({ url, file }) => ({
+      title: 'Free Video',
+      subtitle: file?.asset ? 'Uploaded file' : url || 'No video set',
+    }),
   },
 })
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -76,6 +76,7 @@ export interface GallerySection {
 export interface VideoSection {
   _type: "videoSection";
   _key: string;
+  videoFile?: { asset: { url: string } };
   vimeoUrl?: string;
   caption?: string;
   autoplay?: boolean;
@@ -129,6 +130,7 @@ export interface FreeImageObject extends FreePositionFields {
 export interface FreeVideoObject extends FreePositionFields {
   _type: "freeVideoObject";
   _key: string;
+  videoFile?: { asset: { url: string } };
   vimeoUrl?: string;
   autoplay?: boolean;
   loop?: boolean;


### PR DESCRIPTION
## Summary
This PR adds support for uploading native video files (MP4/WebM) as an alternative to Vimeo embeds, implements a facade pattern for Vimeo videos with poster image previews, and improves caching strategy with on-demand revalidation.

## Key Changes

- **Native Video File Support**: Added `videoFile` field to both `VideoSection` and `FreeVideoObject` schemas, allowing direct MP4/WebM uploads that take priority over Vimeo URLs
- **Vimeo Facade Pattern**: Implemented lazy-loading for Vimeo embeds with custom poster image and play button overlay, improving perceived performance and reducing initial iframe load
- **Enhanced Image Optimization**: Added blur placeholder (LQIP) support for poster images and project cover images using Sanity's metadata
- **On-Demand Revalidation**: Created `/api/revalidate` webhook endpoint for Sanity to trigger ISR, replacing fixed 60-second revalidation intervals with `revalidate: false`
- **Improved Video Component Logic**: Reorganized `VideoSectionComponent` and `FreeVideoObjectComponent` to check for native video files first, with Vimeo as fallback
- **Better UX for Vimeo**: Changed autoplay parameter from "0" to "1" for muted Vimeo embeds and added interactive play button with hover effects

## Implementation Details

- Native video playback uses standard HTML5 `<video>` element with controls, loop, and preload metadata
- Vimeo embed only loads on user interaction (click), reducing unnecessary iframe initialization
- Poster images are optimized with Next.js `Image` component using responsive sizing and blur placeholders
- Schema previews updated to show "Uploaded file" vs URL status in Sanity Studio
- Webhook secret validation ensures only authorized Sanity requests trigger revalidation
- Fallback logic handles both uploaded files and Vimeo URLs gracefully with proper null checks

https://claude.ai/code/session_015ygnkmJ8yx22ZS4meiv2ca